### PR TITLE
Add seirdy.one

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,8 @@ sites:
       text: '#000000'
       links: '#0426fd'
     font_stack: '-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji",Segoe UI Symbol'
+  - name: seirdy
+    url: https://seirdy.one/
 
 default_colors:
   border: '#000000'


### PR DESCRIPTION
I'd like to join this webring.

My site is built by a static site generator. During each build, my SSG pipeline will fetch the next/prev webring links from the config.yaml file so I can include them directly in my markup. I hope it's okay to do that instead of embedding the frame.