### PR TITLE
Add "themathjester" to webring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,18 @@ sites:
       text: '#000000'
       links: '#0426fd'
     font_stack: '-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji",Segoe UI Symbol'
+  - name: chozorho
+    url: https://themathjester.com/
+    colors:
+      border: 'transparent'
+      text: '#ffffff'
+      links: '#0426fd'
+    stylesheets:
+      - https://themathjester.com/main_stylesheet.css
+      - https://themathjester.com/lab/lab_stylesheet.css
+      - https://themathjester.com/lab/colors.css
+    font_stack: '"Love Letter", Fira'
+    font_size: 1em
 
 default_colors:
   border: '#000000'


### PR DESCRIPTION
I have an old-fashioned site where I write blog posts about technology and society. The technical lessons are mainly about C++, Unix commands, lessons I've learned in running a Linux server, and impressive algorithms and theorems in mathematics. The blog posts so far are criticisms of major social media sites and missed opportunities with computers, but they will expand to cover other topics, like phone technology.

Please let me know if I may join, and what I may need to add/remove in order to qualify.

[Site homepage](https://themathjester.com/)